### PR TITLE
fix(security): upgrade gunicorn to fix HTTP Request Smuggling CVEs

### DIFF
--- a/round_1/requirements.txt
+++ b/round_1/requirements.txt
@@ -1,2 +1,2 @@
 flask==3.0.0
-gunicorn==21.2.0
+gunicorn==23.0.0


### PR DESCRIPTION
## Summary
Upgrades gunicorn from 21.2.0 to 23.0.0 to fix HIGH severity security vulnerabilities.

## Security Fixes
| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2024-1135 | HIGH | HTTP Request Smuggling due to improper Transfer-Encoding header validation |
| CVE-2024-6827 | HIGH | HTTP Request Smuggling in gunicorn |

## Changes
- `round_1/requirements.txt`: gunicorn 21.2.0 -> 23.0.0

## Test plan
- [x] All 108 tests pass locally
- [x] Container builds successfully
- [ ] CI pipeline passes
- [ ] Security scan shows no HIGH/CRITICAL CVEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)