### PR TITLE
feat: add emoji-only help overlay

### DIFF
--- a/round_1/src/static/game.js
+++ b/round_1/src/static/game.js
@@ -26,6 +26,9 @@ class EmojiZorkGame {
             errorFlash: document.getElementById("error-flash"),
             retryBtn: document.getElementById("retry-btn"),
             playAgainBtn: document.getElementById("play-again-btn"),
+            helpBtn: document.getElementById("help-btn"),
+            helpOverlay: document.getElementById("help-overlay"),
+            helpCloseBtn: document.getElementById("help-close-btn"),
         };
 
         // Confetti emoji options
@@ -92,6 +95,13 @@ class EmojiZorkGame {
         // Keyboard controls
         document.addEventListener("keydown", (e) => this.handleKeyboard(e));
 
+        // Help overlay
+        this.elements.helpBtn.addEventListener("click", () => this.toggleHelp());
+        this.elements.helpCloseBtn.addEventListener("click", () => this.hideHelp());
+        this.elements.helpOverlay.addEventListener("click", (e) => {
+            if (e.target === this.elements.helpOverlay) this.hideHelp();
+        });
+
         // Item selection in room
         this.elements.visibleItems.addEventListener("click", (e) => {
             if (e.target.classList.contains("item")) {
@@ -121,6 +131,25 @@ class EmojiZorkGame {
      * Handle keyboard input for game controls.
      */
     handleKeyboard(e) {
+        // Escape closes help
+        if (e.key === "Escape") {
+            e.preventDefault();
+            this.hideHelp();
+            return;
+        }
+
+        // ? or / toggles help
+        if (e.key === "?" || (e.key === "/" && !e.shiftKey)) {
+            e.preventDefault();
+            this.toggleHelp();
+            return;
+        }
+
+        // Don't process game keys if help is open
+        if (!this.elements.helpOverlay.classList.contains("hidden")) {
+            return;
+        }
+
         // Ignore if animating or game over (unless restart key)
         if (this.isAnimating) return;
 
@@ -371,8 +400,17 @@ class EmojiZorkGame {
         this.elements.deathOverlay.classList.add("hidden");
         this.elements.grueOverlay.classList.add("hidden");
         this.elements.victoryOverlay.classList.add("hidden");
+        this.elements.helpOverlay.classList.add("hidden");
         this.clearConfetti();
         this.currentRoomId = null; // Reset to trigger particle refresh
+    }
+
+    toggleHelp() {
+        this.elements.helpOverlay.classList.toggle("hidden");
+    }
+
+    hideHelp() {
+        this.elements.helpOverlay.classList.add("hidden");
     }
 
     async restart() {

--- a/round_1/src/static/index.html
+++ b/round_1/src/static/index.html
@@ -53,6 +53,42 @@
             <button class="action-btn" data-action="attack" disabled>⚔️</button>
             <button class="action-btn" data-action="use-potion" disabled>🧪</button>
             <button class="action-btn" data-action="use-key" disabled>🔑</button>
+            <button id="help-btn" class="action-btn help-btn">❓</button>
+        </div>
+    </div>
+
+    <!-- Help Overlay -->
+    <div id="help-overlay" class="overlay hidden">
+        <div class="overlay-content help-content">
+            <div class="help-title">📖</div>
+            <div class="help-grid">
+                <div class="help-section">
+                    <span class="help-icon">🚶</span>
+                    <div class="help-keys">⬆️⬇️⬅️➡️</div>
+                </div>
+                <div class="help-section">
+                    <span class="help-icon">👁️</span>
+                    <div class="help-keys">🔍</div>
+                </div>
+                <div class="help-section">
+                    <span class="help-icon">🖐️</span>
+                    <div class="help-keys">👆➡️🎒</div>
+                </div>
+                <div class="help-section">
+                    <span class="help-icon">⚔️</span>
+                    <div class="help-keys">🗡️➡️👹</div>
+                </div>
+                <div class="help-section">
+                    <span class="help-icon">🧪</span>
+                    <div class="help-keys">➡️❤️❤️</div>
+                </div>
+                <div class="help-section">
+                    <span class="help-icon">🔑</span>
+                    <div class="help-keys">➡️🔓</div>
+                </div>
+            </div>
+            <div class="help-goal">🎯 🐉➡️👑</div>
+            <button id="help-close-btn" class="retry-btn">✖️</button>
         </div>
     </div>
 

--- a/round_1/src/static/styles.css
+++ b/round_1/src/static/styles.css
@@ -469,6 +469,64 @@ body {
 }
 
 /* ==========================================================================
+   Help Overlay
+   ========================================================================== */
+.help-btn {
+    background: var(--color-warning) !important;
+}
+
+.help-btn:hover:not(:disabled) {
+    box-shadow: 0 0 15px var(--color-warning);
+}
+
+.help-content {
+    background: var(--color-panel);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-lg);
+    max-width: 320px;
+}
+
+.help-title {
+    font-size: 3rem;
+    text-align: center;
+    margin-bottom: var(--spacing-md);
+}
+
+.help-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+}
+
+.help-section {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm);
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 8px;
+}
+
+.help-icon {
+    font-size: 1.8rem;
+}
+
+.help-keys {
+    font-size: 1rem;
+    opacity: 0.8;
+}
+
+.help-goal {
+    font-size: 1.5rem;
+    text-align: center;
+    padding: var(--spacing-sm);
+    background: rgba(255, 215, 0, 0.2);
+    border-radius: 8px;
+    margin-bottom: var(--spacing-md);
+}
+
+/* ==========================================================================
    Ambient Particles
    ========================================================================== */
 .ambient-container {


### PR DESCRIPTION
## Summary
Adds a completely emoji-based help screen for new players to understand the game.

## Features
- ❓ Help button in action bar
- All-emoji instructions (no text!)
- Shows: movement, actions, and goal
- Keyboard shortcuts: `?` or `/` to toggle, `Escape` to close
- Click outside overlay to dismiss

## Help Content
| Icon | Meaning |
|------|---------|
| 🚶 ⬆️⬇️⬅️➡️ | Move with arrows |
| 👁️ 🔍 | Look around |
| 🖐️ 👆➡️🎒 | Take items to inventory |
| ⚔️ 🗡️➡️👹 | Attack enemies with sword |
| 🧪 ➡️❤️❤️ | Potion heals health |
| 🔑 ➡️🔓 | Key unlocks doors |
| 🎯 🐉➡️👑 | Goal: defeat dragon, get crown! |

## Test plan
- [x] All 108 tests pass
- [x] Lint passes
- [ ] Manual test help overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)