### PR TITLE
fix: build multi-platform container images (amd64 + arm64)

### DIFF
--- a/.github/workflows/round-1-ci.yml
+++ b/.github/workflows/round-1-ci.yml
@@ -88,6 +88,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU (for multi-platform builds)
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -112,13 +115,14 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: round_1
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Test container starts
+      - name: Test container starts (amd64)
         run: |
           docker build -t emoji-zork-test .
           docker run -d --name test-container -p 8080:8080 emoji-zork-test


### PR DESCRIPTION
## Summary
Fixes container not running on Apple Silicon Macs by building for both amd64 and arm64.

## Changes
- Added `docker/setup-qemu-action@v3` for cross-platform emulation
- Added `platforms: linux/amd64,linux/arm64` to build step

## Test plan
- [ ] CI passes
- [ ] Container runs on Apple Silicon Mac
- [ ] Container runs on Intel Mac/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)