### PR TITLE
fix: ensure findings list updates when version changes

### DIFF
--- a/round_2/frontend/src/components/FindingsList.jsx
+++ b/round_2/frontend/src/components/FindingsList.jsx
@@ -1,5 +1,5 @@
 // PURPOSE: Expandable findings list component with severity-based styling and animations
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 const SEVERITY_CONFIG = {
@@ -159,6 +159,11 @@ function FindingItem({ finding, index }) {
 export default function FindingsList({ findings }) {
   const [filterSeverity, setFilterSeverity] = useState('ALL');
 
+  // Reset filter when findings change (e.g., version switch)
+  useEffect(() => {
+    setFilterSeverity('ALL');
+  }, [findings]);
+
   const filteredFindings = filterSeverity === 'ALL'
     ? findings
     : findings.filter(f => f.severity?.toUpperCase() === filterSeverity);
@@ -216,7 +221,7 @@ export default function FindingsList({ findings }) {
       <div className="space-y-3">
         {filteredFindings.length > 0 ? (
           filteredFindings.map((finding, index) => (
-            <FindingItem key={index} finding={finding} index={index} />
+            <FindingItem key={`${finding.name}-${finding.severity}-${index}`} finding={finding} index={index} />
           ))
         ) : (
           <motion.div


### PR DESCRIPTION
## Problem
When switching versions in the version picker dropdown, the findings list sometimes showed stale CVE data because React wasn't properly re-rendering the components.

## Root Cause
1. **Wrong React keys**: `FindingItem` used `key={index}` which caused React to not re-render items when findings changed but the count stayed similar
2. **Stale filter state**: The severity filter persisted between version switches

## Solution
- Use unique keys: `key={\`${finding.name}-${finding.severity}-${index}\`}`
- Add `useEffect` to reset filter to 'ALL' when findings prop changes

## Testing
1. Search for `lodash`
2. Switch between versions `4.17.21` (0 CVEs) and `4.16.6` (7 CVEs)
3. Verify findings list updates correctly