### PR TITLE
feat(frontend): web UI with dark terminal aesthetic

### DIFF
--- a/round_3/backend/main.py
+++ b/round_3/backend/main.py
@@ -3,14 +3,20 @@
 
 from fastapi import FastAPI, HTTPException, Header
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from typing import Literal, Optional
+from pathlib import Path
 import random
 import uuid
 
 from services.analyzer import analyze
 from services.caption_selector import select_caption, get_sbom_commentary, get_paranoia_message
 from services import paranoia as paranoia_service
+
+# Path to frontend directory
+FRONTEND_DIR = Path(__file__).parent.parent / "frontend"
 
 
 class RoastRequest(BaseModel):
@@ -86,7 +92,10 @@ async def healthz():
 
 @app.get("/")
 async def root():
-    """Root endpoint - redirect to docs or show welcome."""
+    """Serve frontend index.html."""
+    index_path = FRONTEND_DIR / "index.html"
+    if index_path.exists():
+        return FileResponse(index_path)
     return {
         "name": "PARANOID",
         "tagline": "Paste your dependencies. Get roasted. Question everything.",
@@ -96,6 +105,12 @@ async def root():
             "docs": "/docs"
         }
     }
+
+
+@app.get("/app.js")
+async def serve_app_js():
+    """Serve frontend JavaScript."""
+    return FileResponse(FRONTEND_DIR / "app.js", media_type="application/javascript")
 
 
 @app.get("/paranoia")

--- a/round_3/frontend/app.js
+++ b/round_3/frontend/app.js
@@ -1,0 +1,243 @@
+// PURPOSE: Frontend JavaScript for PARANOID SBOM Roast Generator
+// Handles API calls, session management, and UI updates
+
+const API_BASE = window.location.hostname === 'localhost'
+    ? 'http://localhost:8000'
+    : '';  // Same origin in production
+
+// Session management
+let sessionId = localStorage.getItem('paranoid_session') || crypto.randomUUID();
+localStorage.setItem('paranoid_session', sessionId);
+
+// DOM elements
+const inputType = document.getElementById('input-type');
+const inputContent = document.getElementById('input-content');
+const roastBtn = document.getElementById('roast-btn');
+const randomBtn = document.getElementById('random-btn');
+const results = document.getElementById('results');
+const errorBox = document.getElementById('error-box');
+const errorMessage = document.getElementById('error-message');
+const loading = document.getElementById('loading');
+const roastSummary = document.getElementById('roast-summary').querySelector('p');
+const caption = document.getElementById('caption');
+const findingsList = document.getElementById('findings-list');
+const sbomJson = document.getElementById('sbom-json');
+
+// Paranoia display
+const levelName = document.getElementById('level-name');
+const paranoiaMessage = document.getElementById('paranoia-message');
+const levelDots = [
+    document.getElementById('level-0'),
+    document.getElementById('level-1'),
+    document.getElementById('level-2')
+];
+
+// Random terrible examples for "Roast Me" button
+const TERRIBLE_EXAMPLES = {
+    package_json: `{
+  "dependencies": {
+    "lodash": "^4.17.11",
+    "moment": "^2.24.0",
+    "request": "^2.88.0",
+    "left-pad": "^1.3.0",
+    "event-stream": "^3.3.4",
+    "colors": "^1.4.0",
+    "express": "^4.17.1",
+    "jquery": "^3.5.0",
+    "react": "^16.8.0",
+    "webpack": "^4.41.0"
+  },
+  "devDependencies": {
+    "mocha": "^5.2.0",
+    "chai": "^4.2.0"
+  }
+}`,
+    requirements_txt: `flask==1.0.0
+requests==2.20.0
+django==2.0.0
+pillow==5.0.0
+numpy==1.14.0
+pandas==0.23.0
+sqlalchemy==1.2.0
+celery==4.1.0
+redis==2.10.0
+boto3==1.7.0
+urllib3==1.24.0
+pyyaml==3.12`
+};
+
+function updateParanoiaDisplay(paranoia) {
+    if (!paranoia) return;
+
+    const level = paranoia.level || 0;
+    const name = paranoia.level_name || 'CHILL';
+    const message = paranoia.message || '';
+
+    // Update level name and color
+    levelName.textContent = name;
+    levelName.className = 'ml-2';
+
+    if (level === 0) {
+        levelName.classList.add('text-terminal-green');
+    } else if (level === 1) {
+        levelName.classList.add('text-terminal-amber');
+    } else {
+        levelName.classList.add('text-terminal-red', 'glow-red');
+    }
+
+    // Update dots
+    levelDots.forEach((dot, i) => {
+        dot.className = 'w-4 h-4 rounded';
+        if (i <= level) {
+            if (level === 0) dot.classList.add('bg-terminal-green');
+            else if (level === 1) dot.classList.add('bg-terminal-amber');
+            else dot.classList.add('bg-terminal-red');
+        } else {
+            dot.classList.add('bg-gray-700');
+        }
+    });
+
+    // Update message
+    paranoiaMessage.textContent = message;
+}
+
+function showError(message) {
+    errorMessage.textContent = message;
+    errorBox.classList.remove('hidden');
+    results.classList.add('hidden');
+    loading.classList.add('hidden');
+}
+
+function showResults(data) {
+    errorBox.classList.add('hidden');
+    loading.classList.add('hidden');
+    results.classList.remove('hidden');
+
+    // Roast summary
+    roastSummary.textContent = data.roast_summary;
+
+    // Caption
+    caption.textContent = data.caption;
+
+    // Findings
+    findingsList.innerHTML = '';
+    for (const finding of data.findings) {
+        const div = document.createElement('div');
+        div.className = 'flex items-center gap-2 p-2 rounded bg-terminal-text/5';
+
+        const severityColors = {
+            critical: 'text-terminal-red',
+            high: 'text-terminal-red',
+            medium: 'text-terminal-amber',
+            low: 'text-terminal-green',
+            info: 'text-terminal-blue'
+        };
+        const color = severityColors[finding.severity] || 'text-terminal-text';
+
+        div.innerHTML = `
+            <span class="uppercase text-xs ${color}">[${finding.severity}]</span>
+            <span class="text-sm">${finding.detail}</span>
+        `;
+        findingsList.appendChild(div);
+    }
+
+    // SBOM
+    if (data.sbom) {
+        sbomJson.textContent = JSON.stringify(data.sbom, null, 2);
+    }
+
+    // Update paranoia
+    updateParanoiaDisplay(data.paranoia);
+}
+
+async function doRoast() {
+    const type = inputType.value;
+    const content = inputContent.value.trim();
+
+    if (!content) {
+        showError('Your input is empty. Much like your security strategy.');
+        return;
+    }
+
+    // Show loading
+    loading.classList.remove('hidden');
+    results.classList.add('hidden');
+    errorBox.classList.add('hidden');
+    roastBtn.disabled = true;
+
+    try {
+        const response = await fetch(`${API_BASE}/roast`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Session-Id': sessionId
+            },
+            body: JSON.stringify({
+                input_type: type,
+                content: content,
+                include_sbom: true
+            })
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            // Handle special error codes
+            if (response.status === 451) {
+                showError(`HTTP 451 - ${data.detail}`);
+            } else if (response.status === 503) {
+                showError(data.detail);
+            } else {
+                showError(data.detail || 'Something went wrong.');
+            }
+            return;
+        }
+
+        showResults(data);
+
+    } catch (err) {
+        showError(`Network error: ${err.message}. Is the backend running?`);
+    } finally {
+        roastBtn.disabled = false;
+        loading.classList.add('hidden');
+    }
+}
+
+function loadRandomExample() {
+    const type = inputType.value;
+    if (TERRIBLE_EXAMPLES[type]) {
+        inputContent.value = TERRIBLE_EXAMPLES[type];
+    } else {
+        inputContent.value = 'lodash@4.17.11';
+        inputType.value = 'single_package';
+    }
+}
+
+// Fetch initial paranoia state
+async function fetchParanoiaState() {
+    try {
+        const response = await fetch(`${API_BASE}/paranoia`, {
+            headers: { 'X-Session-Id': sessionId }
+        });
+        if (response.ok) {
+            const data = await response.json();
+            updateParanoiaDisplay(data);
+        }
+    } catch (err) {
+        console.log('Could not fetch paranoia state:', err);
+    }
+}
+
+// Event listeners
+roastBtn.addEventListener('click', doRoast);
+randomBtn.addEventListener('click', loadRandomExample);
+
+// Allow Ctrl+Enter to submit
+inputContent.addEventListener('keydown', (e) => {
+    if (e.ctrlKey && e.key === 'Enter') {
+        doRoast();
+    }
+});
+
+// Initialize
+fetchParanoiaState();

--- a/round_3/frontend/index.html
+++ b/round_3/frontend/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PARANOID - SBOM Roast Generator</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        terminal: {
+                            bg: '#0d1117',
+                            text: '#c9d1d9',
+                            green: '#39d353',
+                            amber: '#d29922',
+                            red: '#f85149',
+                            blue: '#58a6ff'
+                        }
+                    },
+                    fontFamily: {
+                        mono: ['JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'monospace']
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { background-color: #0d1117; }
+        .glow-green { text-shadow: 0 0 10px #39d353; }
+        .glow-amber { text-shadow: 0 0 10px #d29922; }
+        .glow-red { text-shadow: 0 0 10px #f85149; }
+        .blink { animation: blink 1s step-end infinite; }
+        @keyframes blink { 50% { opacity: 0; } }
+        pre { white-space: pre-wrap; word-wrap: break-word; }
+    </style>
+</head>
+<body class="min-h-screen font-mono text-terminal-text p-4">
+    <div class="max-w-4xl mx-auto">
+        <!-- Header -->
+        <header class="mb-8 text-center">
+            <h1 class="text-4xl font-bold text-terminal-green glow-green mb-2">PARANOID</h1>
+            <p class="text-terminal-text opacity-80">Paste your dependencies. Get roasted. Question everything.</p>
+        </header>
+
+        <!-- Paranoia Indicator -->
+        <div id="paranoia-bar" class="mb-6 p-3 rounded border border-terminal-green/30 bg-terminal-bg">
+            <div class="flex items-center justify-between">
+                <span class="text-sm">PARANOIA LEVEL:</span>
+                <div class="flex gap-2 items-center">
+                    <div id="level-0" class="w-4 h-4 rounded bg-terminal-green"></div>
+                    <div id="level-1" class="w-4 h-4 rounded bg-gray-700"></div>
+                    <div id="level-2" class="w-4 h-4 rounded bg-gray-700"></div>
+                    <span id="level-name" class="ml-2 text-terminal-green">CHILL</span>
+                </div>
+            </div>
+            <p id="paranoia-message" class="text-xs mt-2 opacity-60">System nominal.</p>
+        </div>
+
+        <!-- Input Section -->
+        <div class="mb-6">
+            <div class="flex gap-4 mb-3">
+                <select id="input-type" class="bg-terminal-bg border border-terminal-green/50 rounded px-3 py-2 text-terminal-text focus:outline-none focus:border-terminal-green">
+                    <option value="package_json">package.json</option>
+                    <option value="requirements_txt">requirements.txt</option>
+                    <option value="single_package">Single Package</option>
+                </select>
+                <button id="roast-btn" class="bg-terminal-green text-terminal-bg px-6 py-2 rounded font-bold hover:bg-terminal-green/80 transition">
+                    ROAST ME
+                </button>
+                <button id="random-btn" class="border border-terminal-amber text-terminal-amber px-4 py-2 rounded hover:bg-terminal-amber/20 transition">
+                    Random
+                </button>
+            </div>
+            <textarea
+                id="input-content"
+                class="w-full h-48 bg-terminal-bg border border-terminal-green/30 rounded p-4 text-terminal-text font-mono resize-none focus:outline-none focus:border-terminal-green"
+                placeholder="Paste your package.json, requirements.txt, or enter a package name..."
+            ></textarea>
+        </div>
+
+        <!-- Results Section -->
+        <div id="results" class="hidden">
+            <!-- Roast Summary -->
+            <div id="roast-summary" class="mb-6 p-4 rounded border border-terminal-amber/50 bg-terminal-amber/10">
+                <p class="text-terminal-amber font-bold"></p>
+            </div>
+
+            <!-- Caption -->
+            <div id="caption-box" class="mb-6 p-4 rounded border border-terminal-green/50 bg-terminal-green/10 text-center">
+                <p id="caption" class="text-xl text-terminal-green font-bold"></p>
+            </div>
+
+            <!-- Findings -->
+            <div id="findings" class="mb-6">
+                <h3 class="text-terminal-blue mb-2">Findings:</h3>
+                <div id="findings-list" class="space-y-2"></div>
+            </div>
+
+            <!-- SBOM (Collapsible) -->
+            <details class="mb-6 border border-terminal-text/20 rounded">
+                <summary class="p-3 cursor-pointer hover:bg-terminal-text/5">
+                    SBOM Output <span class="text-xs opacity-60">(click to expand)</span>
+                </summary>
+                <div id="sbom-content" class="p-4 bg-terminal-bg">
+                    <pre id="sbom-json" class="text-xs text-terminal-text/80 overflow-auto max-h-64"></pre>
+                </div>
+            </details>
+        </div>
+
+        <!-- Error Display -->
+        <div id="error-box" class="hidden mb-6 p-4 rounded border border-terminal-red/50 bg-terminal-red/10">
+            <p id="error-message" class="text-terminal-red"></p>
+        </div>
+
+        <!-- Loading -->
+        <div id="loading" class="hidden text-center py-8">
+            <p class="text-terminal-green">Analyzing dependencies<span class="blink">_</span></p>
+        </div>
+
+        <!-- Footer -->
+        <footer class="mt-12 text-center text-xs opacity-40">
+            <p>Built on Chainguard images. No shell. Maximum paranoia.</p>
+            <p class="mt-1">SBOM confidence: LOW (as is tradition)</p>
+        </footer>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `frontend/index.html` - Tailwind CSS via CDN, dark terminal theme
- `frontend/app.js` - Vanilla JS (~150 lines), no build step

## Features
- Dark terminal aesthetic with green/amber/red accents
- Paranoia level indicator (3 dots that change color)
- Input type selector (package.json, requirements.txt, single package)
- Results display with findings list
- Collapsible SBOM viewer
- "Random" button loads terrible example dependencies
- Session tracking via localStorage X-Session-Id
- Ctrl+Enter keyboard shortcut

## UI Preview
- Header: "PARANOID - Paste your dependencies. Get roasted."
- Paranoia bar: Level dots + status message
- Textarea for pasting deps
- Results: Summary, caption, findings, SBOM
- Footer: "Built on Chainguard images. No shell. Maximum paranoia."

## Test Plan
- [x] Frontend loads at /
- [x] POST /roast works from UI
- [x] Paranoia display updates
- [x] SBOM collapsible works
- [x] Error handling shows 451, 503, 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)