### PR TITLE
feat: Dockerfile and deployment configuration

### DIFF
--- a/round_3/.dockerignore
+++ b/round_3/.dockerignore
@@ -1,0 +1,11 @@
+# PURPOSE: Docker ignore file to keep image lean
+.git
+.gitignore
+*.md
+docs/
+*.pyc
+__pycache__
+.pytest_cache
+.env
+*.png
+backend/static/memes/*.png

--- a/round_3/.gitignore
+++ b/round_3/.gitignore
@@ -1,0 +1,1 @@
+backend/static/memes/*.png

--- a/round_3/Dockerfile
+++ b/round_3/Dockerfile
@@ -1,0 +1,34 @@
+# PURPOSE: Dockerfile for PARANOID - SBOM Roast Generator
+# Using Chainguard images for maximum paranoia (no shell, minimal attack surface)
+
+FROM cgr.dev/chainguard/python:latest-dev AS builder
+
+WORKDIR /app
+
+# Copy requirements first for layer caching
+COPY backend/requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt --target /app/deps
+
+# Production image - distroless, no shell
+FROM cgr.dev/chainguard/python:latest
+
+WORKDIR /app
+
+# Copy installed dependencies
+COPY --from=builder /app/deps /app/deps
+
+# Copy application code
+COPY backend/ /app/backend/
+COPY frontend/ /app/frontend/
+COPY run.py /app/
+
+# Set Python path to include deps and backend
+ENV PYTHONPATH=/app/deps:/app/backend
+
+# Expose port (Railway sets PORT env var)
+EXPOSE 8000
+
+# Run via run.py which handles import paths
+ENTRYPOINT ["python", "/app/run.py"]

--- a/round_3/docker-compose.yml
+++ b/round_3/docker-compose.yml
@@ -1,0 +1,16 @@
+# PURPOSE: Docker Compose for local development and testing
+version: '3.8'
+
+services:
+  paranoid:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - PYTHONUNBUFFERED=1
+    volumes:
+      # Mount memes directory for persistence (optional)
+      - meme-storage:/app/backend/static/memes
+
+volumes:
+  meme-storage:

--- a/round_3/run.py
+++ b/round_3/run.py
@@ -1,0 +1,15 @@
+# PURPOSE: Entry point for production deployment (Railway, etc.)
+# Sets up paths and runs uvicorn with correct imports
+
+import os
+import sys
+
+# Add backend to path so imports work
+backend_dir = os.path.join(os.path.dirname(__file__), "backend")
+sys.path.insert(0, backend_dir)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run("main:app", host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile using Chainguard distroless Python images
- No shell, minimal attack surface (maximum paranoia)
- docker-compose.yml for local development
- run.py entry point for Railway/cloud deployment

## Key Details
- Uses `cgr.dev/chainguard/python:latest-dev` for build stage (has pip)
- Uses `cgr.dev/chainguard/python:latest` for runtime (distroless)
- Respects PORT env var for Railway deployment
- .dockerignore keeps image lean

## Test Plan
- [ ] `docker build -t paranoid .` completes successfully
- [ ] `docker run -p 8000:8000 paranoid` serves the app
- [ ] `/healthz` returns 200

## Note
Should be merged after #16 (meme system) to include Pillow in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)