### PR TITLE
fix: AI level dropdown enables when AI is ON

### DIFF
--- a/round_3/frontend/app.js
+++ b/round_3/frontend/app.js
@@ -512,17 +512,9 @@ function toggleAi() {
     aiToggle.dataset.enabled = newState.toString();
     aiToggle.textContent = newState ? 'ON' : 'OFF';
     
-    // Enable/disable reasoning level dropdown
+    // Enable/disable reasoning level dropdown (CSS handles styling via :disabled selector)
     if (aiLevel) {
-        if (newState) {
-            aiLevel.disabled = false;
-            aiLevel.classList.remove('opacity-50', 'cursor-not-allowed', 'text-gray-500', 'border-gray-600');
-            aiLevel.classList.add('text-terminal-blue', 'border-terminal-blue/50');
-        } else {
-            aiLevel.disabled = true;
-            aiLevel.classList.add('opacity-50', 'cursor-not-allowed', 'text-gray-500', 'border-gray-600');
-            aiLevel.classList.remove('text-terminal-blue', 'border-terminal-blue/50');
-        }
+        aiLevel.disabled = !newState;
     }
     
     // Update styling

--- a/round_3/frontend/index.html
+++ b/round_3/frontend/index.html
@@ -35,6 +35,20 @@
         @keyframes blink { 50% { opacity: 0; } }
         pre { white-space: pre-wrap; word-wrap: break-word; }
         
+        /* AI level dropdown states */
+        #ai-level:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            border-color: #4b5563;
+            color: #6b7280;
+        }
+        #ai-level:not(:disabled) {
+            opacity: 1;
+            cursor: pointer;
+            border-color: #58a6ff;
+            color: #58a6ff;
+        }
+        
         /* MELTDOWN glitch effect */
         .glitch-mode {
             animation: glitch 0.3s infinite;
@@ -66,7 +80,7 @@
             <button id="ai-toggle" class="px-3 py-1 rounded font-bold text-xs transition border border-terminal-blue text-terminal-blue hover:bg-terminal-blue/20" data-enabled="false">
                 OFF
             </button>
-            <select id="ai-level" disabled class="bg-terminal-bg border border-gray-600 rounded px-2 py-1 text-xs text-gray-500 focus:outline-none opacity-50 cursor-not-allowed">
+            <select id="ai-level" disabled class="ai-level-disabled bg-terminal-bg border rounded px-2 py-1 text-xs focus:outline-none">
                 <option value="low">Haiku (Fast)</option>
                 <option value="medium" selected>Sonnet (Balanced)</option>
                 <option value="high">Opus (Best)</option>


### PR DESCRIPTION
## Summary
Fixes the AI reasoning level dropdown not enabling when the AI toggle is turned ON.

## Changes
- Added CSS `:disabled` and `:not(:disabled)` selectors for dropdown styling
- Simplified JavaScript to just toggle the `disabled` attribute
- CSS now handles all visual states:
  - Disabled: grayed out, cursor not-allowed, 50% opacity
  - Enabled: blue border/text, full opacity, pointer cursor

## Testing
1. Load the app
2. Click AI toggle to ON
3. Dropdown should now be blue and selectable
4. Select different models (Haiku/Sonnet/Opus)
5. Toggle AI OFF - dropdown should gray out again