### PR TITLE
feat: go.mod parsing (REQ-008) and digital signatures (REQ-053)

### DIFF
--- a/round_3/backend/services/signer.py
+++ b/round_3/backend/services/signer.py
@@ -1,0 +1,55 @@
+# PURPOSE: Digital signature generation for PARANOID roast responses
+# Signs responses with SHA256 hash to prove "authenticity" (for comedy)
+
+import base64
+import hashlib
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _get_salt() -> str:
+    """Get the salt for hashing. Uses app name as salt."""
+    return "paranoid-roaster-v1"
+
+
+def sign_response(data: dict) -> str:
+    """Sign a response dict and return base64-encoded signature.
+    
+    Uses SHA256 hash with salt for demo purposes.
+    This is NOT cryptographically secure - it's for comedic "authenticity".
+    
+    Args:
+        data: The response dict to sign (will be JSON-serialized)
+    
+    Returns:
+        Base64-encoded signature string
+    """
+    # Create canonical JSON (sorted keys, no extra whitespace)
+    canonical = json.dumps(data, sort_keys=True, separators=(',', ':'))
+    
+    # Hash with salt
+    to_hash = f"{_get_salt()}:{canonical}"
+    digest = hashlib.sha256(to_hash.encode('utf-8')).digest()
+    
+    return base64.b64encode(digest).decode('utf-8')
+
+
+def get_signing_method() -> str:
+    """Return the signing method being used."""
+    return "SHA256"
+
+
+def verify_signature(data: dict, signature: str) -> bool:
+    """Verify a signature matches the data.
+    
+    Args:
+        data: The response dict that was signed
+        signature: The base64-encoded signature to verify
+    
+    Returns:
+        True if signature is valid, False otherwise
+    """
+    expected = sign_response(data)
+    return signature == expected

--- a/round_3/frontend/app.js
+++ b/round_3/frontend/app.js
@@ -256,6 +256,35 @@ pexpect==4.4.0`
     {
         type: 'single_package',
         content: 'rc@1.2.8'
+    },
+    // Go examples
+    {
+        type: 'go_mod',
+        content: `module github.com/example/legacy-service
+
+go 1.19
+
+require (
+	github.com/gin-gonic/gin v1.6.0
+	github.com/go-sql-driver/mysql v1.5.0
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	gopkg.in/yaml.v2 v2.2.8
+)`
+    },
+    {
+        type: 'go_mod',
+        content: `module github.com/startup/microservice
+
+go 1.18
+
+require (
+	github.com/gorilla/mux v1.7.0
+	github.com/sirupsen/logrus v1.4.0
+	github.com/jinzhu/gorm v1.9.0
+	github.com/spf13/viper v1.6.0
+	github.com/prometheus/client_golang v1.5.0
+)`
     }
 ];
 

--- a/round_3/frontend/index.html
+++ b/round_3/frontend/index.html
@@ -120,6 +120,7 @@
                 <select id="input-type" class="bg-terminal-bg border border-terminal-green/50 rounded px-2 sm:px-3 py-2 text-sm text-terminal-text focus:outline-none focus:border-terminal-green">
                     <option value="package_json">package.json</option>
                     <option value="requirements_txt">requirements.txt</option>
+                    <option value="go_mod">go.mod</option>
                     <option value="single_package">Single Package</option>
                 </select>
                 <button id="roast-btn" disabled class="bg-terminal-green text-terminal-bg px-4 sm:px-6 py-2 rounded font-bold text-sm transition">


### PR DESCRIPTION
## Summary
Implements two SRS requirements:

### REQ-008: Parse go.mod format
- New `parse_go_mod()` function handles Go module files
- Parses both block `require (...)` and single-line `require` statements
- Extracts module path, version (strips 'v' prefix), and direct/indirect
- Added to frontend dropdown and random examples

**Example input:**
```go
module github.com/example/app

require (
    github.com/gin-gonic/gin v1.9.1
    golang.org/x/crypto v0.14.0 // indirect
)
```

### REQ-053: Digital signatures
- New `services/signer.py` with SHA256-based signing
- Signs core response data (meme_url, caption, summary, etc.)
- Base64-encoded signature in response `signature` field
- Comedic "authenticity" - not cryptographically secure

## Testing
1. Paste a go.mod file → should parse dependencies
2. Check response JSON → should include `signature` field
3. Random button → may show go.mod examples