### PR TITLE
feat: AI-generated SBOM commentary

### DIFF
--- a/round_3/backend/main.py
+++ b/round_3/backend/main.py
@@ -376,6 +376,7 @@ async def roast(request: RoastRequest, req: Request, x_session_id: Optional[str]
     meme_id = str(uuid.uuid4())[:8]
     ai_generated = False
     template_used = "leonardo"
+    ai_sbom_commentary = ""  # Will be set if AI provides it
     
     # Try AI generation if requested and available
     if request.use_ai and is_ai_available():
@@ -401,6 +402,7 @@ async def roast(request: RoastRequest, req: Request, x_session_id: Optional[str]
         if ai_result:
             caption = ai_result.roast
             template_used = ai_result.template
+            ai_sbom_commentary = ai_result.sbom_commentary
             ai_generated = True
     
     # Fallback to pre-written captions if AI not used or failed
@@ -464,7 +466,8 @@ async def roast(request: RoastRequest, req: Request, x_session_id: Optional[str]
 
     # SBOM with actual components
     sbom = None
-    sbom_commentary = get_sbom_commentary()
+    # Use AI-generated commentary if available, otherwise random from captions.json
+    sbom_commentary = ai_sbom_commentary if ai_sbom_commentary else get_sbom_commentary()
     if request.include_sbom:
         components = [
             {"name": d.name, "version": d.version or "unknown", "type": "library"}

--- a/round_3/backend/services/ai_roaster.py
+++ b/round_3/backend/services/ai_roaster.py
@@ -80,6 +80,7 @@ class AIRoastResult:
     roast: str
     template: str
     severity: str
+    sbom_commentary: str = ""  # AI-generated SBOM analysis
     ai_generated: bool = True
 
 
@@ -221,8 +222,13 @@ Example 5 - Pain vibe:
 {{"roast": "Still on Flask 1.0. I'm fine.", "template": "harold", "severity": "medium"}}
 
 ## OUTPUT FORMAT
-Return ONLY valid JSON (under 100 chars for roast):
-{{"roast": "Top text. Bottom text.", "template": "template_id", "severity": "low|medium|high|critical"}}"""
+Return ONLY valid JSON:
+- roast: Under 100 chars, meme text (top. bottom.)
+- template: Template ID from list above
+- severity: low|medium|high|critical
+- sbom_commentary: 1-2 sentences of sarcastic SBOM analysis (reference specific findings!)
+
+{{"roast": "Top text. Bottom text.", "template": "template_id", "severity": "high", "sbom_commentary": "Your SBOM lists 47 CVEs across 12 packages. That's a 3.9 vulnerability-per-dependency ratio. Impressive efficiency."}}"""
 
     return prompt
 
@@ -314,10 +320,14 @@ async def generate_ai_roast(
                 else:
                     roast = roast[:100] + "..."
             
+            # Get SBOM commentary if provided
+            sbom_commentary = result.get("sbom_commentary", "")
+            
             return AIRoastResult(
                 roast=roast,
                 template=template,
                 severity=result.get("severity", "medium"),
+                sbom_commentary=sbom_commentary,
                 ai_generated=True
             )
             


### PR DESCRIPTION
## Summary
When AI is enabled, the SBOM commentary is now generated by Claude based on the actual analysis findings instead of randomly selected from pre-written captions.

## Changes
- Added `sbom_commentary` field to `AIRoastResult` dataclass
- Updated AI prompt to request contextual SBOM commentary
- `main.py` uses AI commentary when available, falls back to random

## Example AI-generated commentaries
Instead of generic:
> "Here's your SBOM. I've enumerated what I could find. I've missed at least 40%."

Now contextual:
> "Your SBOM lists 8 CVEs across 2 packages. That's a 4:1 vulnerability ratio. Impressive efficiency."

> "Found event-stream in here. The SBOM is now evidence in a federal investigation."

> "golang.org/x/crypto - the 'x' stands for 'experimental'. In production. Bold choice."

## Fallback
When AI is disabled or fails, still uses random captions from `captions.json`.