### PR TITLE
fix: filter CVEs by version range

### DIFF
--- a/round_3/backend/services/cve_detector.py
+++ b/round_3/backend/services/cve_detector.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from typing import Optional
 import httpx
 
+from services.osv_client import is_version_affected
+
 logger = logging.getLogger(__name__)
 
 # Load CVE database
@@ -221,6 +223,10 @@ async def query_osv(package_name: str, version: str, ecosystem: str = "npm") -> 
             vulns = data.get("vulns", [])
             
             for vuln in vulns:
+                # Filter by version - OSV API returns all vulns, we need to check ranges
+                if version and not is_version_affected(version, vuln, ecosystem):
+                    continue
+                
                 # Extract CVE ID from aliases
                 cve_id = vuln.get("id", "")
                 for alias in vuln.get("aliases", []):

--- a/round_3/backend/services/osv_client.py
+++ b/round_3/backend/services/osv_client.py
@@ -76,19 +76,24 @@ def version_in_range(
     return True
 
 
-def is_version_affected(version: str, vuln: Dict[str, Any]) -> bool:
+def is_version_affected(version: str, vuln: Dict[str, Any], ecosystem: str = None) -> bool:
     """
     Check if a specific version is affected by a vulnerability.
 
     Parses OSV affected ranges and checks if the version falls within any affected range.
+    
+    Args:
+        version: Version string to check
+        vuln: OSV vulnerability dict
+        ecosystem: Optional ecosystem to filter by (npm, PyPI, Go, etc.)
     """
     if not version:
         return True  # If no version specified, assume affected
 
     for affected in vuln.get("affected", []):
-        # Check if this affects npm ecosystem
         pkg = affected.get("package", {})
-        if pkg.get("ecosystem") != "npm":
+        # If ecosystem specified, filter by it; otherwise check all
+        if ecosystem and pkg.get("ecosystem") != ecosystem:
             continue
 
         for range_info in affected.get("ranges", []):


### PR DESCRIPTION
## Bug
React 18.3.1 was being flagged as vulnerable to CVEs that only affect versions 0.4.x and 0.5.x.

## Root Cause
OSV.dev API returns ALL vulnerabilities for a package regardless of version. We weren't filtering by version ranges.

## Fix
Added version range filtering using `is_version_affected()` from `osv_client.py`:
```python
if version and not is_version_affected(version, vuln, ecosystem):
    continue
```

This parses OSV's `affected.ranges.events` to check if the version falls within:
- `introduced` (inclusive) 
- `fixed` (exclusive) or `last_affected` (inclusive)

## Testing
- React 18.3.1 should now show 0 CVEs (not 8+)
- Packages with actual CVEs in their version range still detected